### PR TITLE
Rename Plugins to TaskProviders

### DIFF
--- a/Polyrific.Catapult.TaskProviders.MSBuild.sln
+++ b/Polyrific.Catapult.TaskProviders.MSBuild.sln
@@ -7,9 +7,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{198CCBB9-7C9
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{4A451222-0C2C-4F36-AD9B-8C6CFCA15857}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polyrific.Catapult.Plugins.MSBuild", "src\Polyrific.Catapult.Plugins.MSBuild\Polyrific.Catapult.Plugins.MSBuild.csproj", "{FFC5859C-3695-45C1-B246-EC7EE300DA38}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Polyrific.Catapult.TaskProviders.MSBuild", "src\Polyrific.Catapult.TaskProviders.MSBuild\Polyrific.Catapult.TaskProviders.MSBuild.csproj", "{FFC5859C-3695-45C1-B246-EC7EE300DA38}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polyrific.Catapult.Plugins.MSBuild.UnitTests", "tests\Polyrific.Catapult.Plugins.MSBuild.UnitTests\Polyrific.Catapult.Plugins.MSBuild.UnitTests.csproj", "{9DC66171-0D1E-4BEE-A654-DA3786ED32EA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polyrific.Catapult.TaskProviders.MSBuild.UnitTests", "tests\Polyrific.Catapult.TaskProviders.MSBuild.UnitTests\Polyrific.Catapult.TaskProviders.MSBuild.UnitTests.csproj", "{9DC66171-0D1E-4BEE-A654-DA3786ED32EA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-# Polyrific.Catapult.Plugins.MSBuild
+# Polyrific.Catapult.TaskProviders.MSBuild
+The Catapult task provider to build .net framework solutions using MSBuild

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: 'Polyrific.Catapult.Plugins.MSBuild'
+name: 'Polyrific.Catapult.TaskProviders.MSBuild'
 type: 'BuildProvider'
 author: 'Polyrific'
 version: '1.0'

--- a/src/Polyrific.Catapult.TaskProviders.MSBuild/Builder.cs
+++ b/src/Polyrific.Catapult.TaskProviders.MSBuild/Builder.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
 using Microsoft.Extensions.Logging;
-using Polyrific.Catapult.Plugins.MSBuild.Helpers;
+using Polyrific.Catapult.TaskProviders.MSBuild.Helpers;
 using System;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
 using System.Threading.Tasks;
 
-namespace Polyrific.Catapult.Plugins.MSBuild
+namespace Polyrific.Catapult.TaskProviders.MSBuild
 {
     public class Builder : IBuilder
     {

--- a/src/Polyrific.Catapult.TaskProviders.MSBuild/Helpers/CommandHelper.cs
+++ b/src/Polyrific.Catapult.TaskProviders.MSBuild/Helpers/CommandHelper.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Polyrific.Catapult.Plugins.MSBuild.Helpers
+namespace Polyrific.Catapult.TaskProviders.MSBuild.Helpers
 {
     public class CommandHelper
     {

--- a/src/Polyrific.Catapult.TaskProviders.MSBuild/IBuilder.cs
+++ b/src/Polyrific.Catapult.TaskProviders.MSBuild/IBuilder.cs
@@ -2,7 +2,7 @@
 
 using System.Threading.Tasks;
 
-namespace Polyrific.Catapult.Plugins.MSBuild
+namespace Polyrific.Catapult.TaskProviders.MSBuild
 {
     public interface IBuilder
     {

--- a/src/Polyrific.Catapult.TaskProviders.MSBuild/Polyrific.Catapult.TaskProviders.MSBuild.csproj
+++ b/src/Polyrific.Catapult.TaskProviders.MSBuild/Polyrific.Catapult.TaskProviders.MSBuild.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polyrific.Catapult.Plugins.Core" Version="1.0.0-beta1-15222" />
+    <PackageReference Include="Polyrific.Catapult.TaskProviders.Core" Version="1.0.0-beta2-*" />
   </ItemGroup>
 
 </Project>

--- a/src/Polyrific.Catapult.TaskProviders.MSBuild/Program.cs
+++ b/src/Polyrific.Catapult.TaskProviders.MSBuild/Program.cs
@@ -1,25 +1,21 @@
 ﻿// Copyright (c) Polyrific, Inc 2018. All rights reserved.
 
-using Polyrific.Catapult.Plugins.Core;
+using Polyrific.Catapult.TaskProviders.Core;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Polyrific.Catapult.Plugins.MSBuild
+namespace Polyrific.Catapult.TaskProviders.MSBuild
 {
     public class Program : BuildProvider
     {
-        private const string TaskProviderName = "Polyrific.Catapult.Plugins.MSBuild";
+        private const string TaskProviderName = "Polyrific.Catapult.TaskProviders.MSBuild";
 
         private readonly IBuilder _builder;
 
         public override string Name => TaskProviderName;
 
-        public Program() : base(new string[0], TaskProviderName)
-        {
-        }
-
-        public Program(string[] args) : base(args, TaskProviderName)
+        public Program(string[] args) : base(args)
         {
             _builder = new Builder(Logger);
         }

--- a/tests/Polyrific.Catapult.TaskProviders.MSBuild.UnitTests/BuildProviderTests.cs
+++ b/tests/Polyrific.Catapult.TaskProviders.MSBuild.UnitTests/BuildProviderTests.cs
@@ -1,13 +1,13 @@
 using Newtonsoft.Json;
-using Polyrific.Catapult.Plugins.Core.Configs;
-using Polyrific.Catapult.Plugins.MSBuild.Helpers;
+using Polyrific.Catapult.TaskProviders.Core.Configs;
+using Polyrific.Catapult.TaskProviders.MSBuild.Helpers;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Polyrific.Catapult.Plugins.MSBuild.UnitTests
+namespace Polyrific.Catapult.TaskProviders.MSBuild.UnitTests
 {
     public class BuildProviderTests
     {

--- a/tests/Polyrific.Catapult.TaskProviders.MSBuild.UnitTests/Polyrific.Catapult.TaskProviders.MSBuild.UnitTests.csproj
+++ b/tests/Polyrific.Catapult.TaskProviders.MSBuild.UnitTests/Polyrific.Catapult.TaskProviders.MSBuild.UnitTests.csproj
@@ -8,13 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Polyrific.Catapult.Plugins.Core" Version="1.0.0-beta1-15222" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Polyrific.Catapult.Plugins.MSBuild\Polyrific.Catapult.Plugins.MSBuild.csproj" />
+    <ProjectReference Include="..\..\src\Polyrific.Catapult.TaskProviders.MSBuild\Polyrific.Catapult.TaskProviders.MSBuild.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Rename the namespace from `Polyrific.Catapult.Plugins.MSBuild` to `Polyrific.Catapult.TaskProviders.MSBuild`
- Update the core library to use `Polyrific.Catapult.TaskProviders.Core`